### PR TITLE
reworked regex for multi-line concordance files

### DIFF
--- a/patchKnitrSynctex.R
+++ b/patchKnitrSynctex.R
@@ -14,7 +14,7 @@ patchKnitrSynctex <- function (texfile){
 		stop(paste(f,"does not exist! Did you set 'opts_knit$set(concordance = TRUE);'?"))
 	text<-readChar(f, file.info(f)$size);
 	require(stringr)
-	re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+)(( \\d+ \\d+)*)\\}";
+	re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+)(( \\d+ \\d+)*)";
 	parsed=str_match_all(text,re);
 	for(i in seq(1,nrow(parsed[[1]]))){		
 		texF=parsed[[1]][i,2];

--- a/patchKnitrSynctex.R
+++ b/patchKnitrSynctex.R
@@ -14,15 +14,16 @@ patchKnitrSynctex <- function (texfile){
 		stop(paste(f,"does not exist! Did you set 'opts_knit$set(concordance = TRUE);'?"))
 	text<-readChar(f, file.info(f)$size);
 	require(stringr)
-#    re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+)(( \\d+ \\d+)*)"
 	re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+ )((\\d+ \\d+[ \\}]\\%?\\r?\\n?)*)";
 	parsed=str_match_all(text,re);
-#	return(parsed)
-    for(i in seq(1,nrow(parsed[[1]]))){		
+	for(i in seq(1,nrow(parsed[[1]]))){		
 		texF=parsed[[1]][i,2];
 		rnwF=parsed[[1]][i,3];
 		startLine=as.integer(parsed[[1]][i,4]);
-		rleValues <- read.table(textConnection(parsed[[1]][i,5]));
+		# Clean newlines and braces from the line concordance data
+		parsedi5_clean <- gsub('[^[:digit:] ]', '', parsed[[1]][i,5])
+		# Coerce cleaned line concordance data to table of values
+		rleValues <- read.table(textConnection(parsedi5_clean));
 		rleO = rle(0);
 		rleO$values=as.numeric(rleValues[seq(2,length(rleValues),2)]);
 		rleO$lengths=as.integer(rleValues[seq(1,length(rleValues),2)]);

--- a/patchKnitrSynctex.R
+++ b/patchKnitrSynctex.R
@@ -14,9 +14,11 @@ patchKnitrSynctex <- function (texfile){
 		stop(paste(f,"does not exist! Did you set 'opts_knit$set(concordance = TRUE);'?"))
 	text<-readChar(f, file.info(f)$size);
 	require(stringr)
-	re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+)(( \\d+ \\d+)*)";
+#    re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+)(( \\d+ \\d+)*)"
+	re="\\\\Sconcordance\\{concordance:([^:]*):([^\\%]*):\\%\\r?\\n(\\d+ )((\\d+ \\d+[ \\}]\\%?\\r?\\n?)*)";
 	parsed=str_match_all(text,re);
-	for(i in seq(1,nrow(parsed[[1]]))){		
+#	return(parsed)
+    for(i in seq(1,nrow(parsed[[1]]))){		
 		texF=parsed[[1]][i,2];
 		rnwF=parsed[[1]][i,3];
 		startLine=as.integer(parsed[[1]][i,4]);


### PR DESCRIPTION
`patchKnitrSynctex` was failing with this concordance file:  

```
\Sconcordance{concordance:commentary.tex:commentary.Rnw:%
1 2 1 49 0 1 11 69 1 1 20 1 1 1 27 10 1 1 27 5 1 7 0 %
77 1 1 7}
```

I determined that the problem was that the regex pattern `re` assumed exactly two lines.  I rewrote `re` to accommodate multiple lines.  This led to errors in the line `rleValues <- read.table(textConnection(parsed[[1]][i,5]));`.  I then determined that the problem was that this element of the regex results now contained non-numeric characters (%, \n, and }).  This element is now passed through `gsub` to remove everything except digits and spaces.  I tested the new version of `patchKnitrSynctex` in situ with the concordance file above and both forward and backward searching appears to be working correctly.  
